### PR TITLE
增加对 undertow 的支持

### DIFF
--- a/motan-extension/protocol-extension/motan-protocol-restful/pom.xml
+++ b/motan-extension/protocol-extension/motan-protocol-restful/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>motan-protocol-restful</artifactId>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <resteasy.version>3.1.3.Final</resteasy.version>
+    <resteasy.version>3.0.7.Final</resteasy.version>
     <junit.version>4.12</junit.version>
     <undertow.version>1.3.25.Final</undertow.version>
   </properties>
@@ -108,11 +108,13 @@
      <groupId>org.jboss.resteasy</groupId>
      <artifactId>resteasy-undertow</artifactId>
      <version>${resteasy.version}</version>
+     <scope>provided</scope>
    </dependency>
    <dependency>
      <groupId>io.undertow</groupId>
      <artifactId>undertow-servlet</artifactId>
      <version>${undertow.version}</version>
+     <scope>provided</scope>
    </dependency>
   </dependencies>
 </project>

--- a/motan-extension/protocol-extension/motan-protocol-restful/pom.xml
+++ b/motan-extension/protocol-extension/motan-protocol-restful/pom.xml
@@ -26,8 +26,9 @@
   <artifactId>motan-protocol-restful</artifactId>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <resteasy.version>3.0.7.Final</resteasy.version>
+    <resteasy.version>3.1.3.Final</resteasy.version>
     <junit.version>4.12</junit.version>
+    <undertow.version>1.3.25.Final</undertow.version>
   </properties>
   <dependencies>
     <dependency>
@@ -102,6 +103,16 @@
      <groupId>org.jboss.resteasy</groupId>
      <artifactId>resteasy-jackson2-provider</artifactId>
      <version>${resteasy.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.jboss.resteasy</groupId>
+     <artifactId>resteasy-undertow</artifactId>
+     <version>${resteasy.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>io.undertow</groupId>
+     <artifactId>undertow-servlet</artifactId>
+     <version>${undertow.version}</version>
    </dependency>
   </dependencies>
 </project>

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestfulProtocol.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestfulProtocol.java
@@ -92,7 +92,7 @@ public class RestfulProtocol extends AbstractProtocol {
 		public void destroy() {
 			endpointFactory.safeReleaseResource(server, url);
 
-			LoggerUtil.info("RestfulExporter destory Success: url={}", url);
+			LoggerUtil.info("RestfulExporter destroy Success: url={}", url);
 		}
 
 		@Override
@@ -112,7 +112,7 @@ public class RestfulProtocol extends AbstractProtocol {
 			super(clz, url);
 
 			endpointFactory = ExtensionLoader.getExtensionLoader(EndpointFactory.class).getExtension(
-					url.getParameter(URLParamType.endpointFactory.getName(), URLParamType.endpointFactory.getValue()));
+					url.getParameter(URLParamType.endpointFactory.getName(), "netty"));
 			target = endpointFactory.createClient(url);
 		}
 
@@ -120,7 +120,7 @@ public class RestfulProtocol extends AbstractProtocol {
 		public void destroy() {
 			endpointFactory.safeReleaseResource(target, url);
 
-			LoggerUtil.info("RestfulReferer destory client: url={}" + url);
+			LoggerUtil.info("RestfulReferer destroy client: url={}" + url);
 		}
 
 		@Override

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
@@ -33,7 +33,7 @@ import com.weibo.api.motan.util.MotanFrameworkUtil;
 
 public abstract class AbstractEndpointFactory implements EndpointFactory {
 	/** 维持share channel 的service列表 **/
-	protected Map<String, RestServer> ipPort2ServerShareChannel = new HashMap<String, RestServer>();
+	protected final Map<String, RestServer> ipPort2ServerShareChannel = new HashMap<String, RestServer>();
 	// 维持share channel 的client列表 <ip:port,client>
 	private final Map<String, ResteasyWebTarget> ipPort2ClientShareChannel = new HashMap<String, ResteasyWebTarget>();
 

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
@@ -15,26 +15,23 @@
  */
 package com.weibo.api.motan.protocol.restful.support;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
-import org.apache.commons.lang3.StringUtils;
-import org.jboss.resteasy.specimpl.BuiltResponse;
-import org.jboss.resteasy.util.Base64;
-
 import com.weibo.api.motan.common.MotanConstants;
 import com.weibo.api.motan.util.LoggerUtil;
 import com.weibo.api.motan.util.StringTools;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.util.Base64;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.io.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class RestfulUtil {
 	public static final String ATTACHMENT_HEADER = "X-Attach";

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
@@ -73,6 +73,15 @@ public class RestfulUtil {
 		return result;
 	}
 
+	public static boolean isRpcRequest(HttpRequest httpRequest) {
+		final HttpHeaders headers = httpRequest.getHttpHeaders();
+		if (headers != null) {
+			final List<String> attachHeaders = headers.getRequestHeader(ATTACHMENT_HEADER);
+			return attachHeaders != null && !attachHeaders.isEmpty();
+		}
+		return false;
+	}
+
 	public static Response serializeError(Exception ex) {
 		try {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RpcExceptionMapper.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RpcExceptionMapper.java
@@ -28,7 +28,7 @@ public class RpcExceptionMapper implements ExceptionMapper<Exception>{
   public Response toResponse(Exception exception){
     HttpRequest httpRequest = ResteasyProviderFactory.getContextData(HttpRequest.class);
     // 当为rpc调用时,序列化异常
-    if(httpRequest != null & !RestfulUtil.decodeAttachments(httpRequest.getMutableHeaders()).isEmpty()){
+    if (httpRequest != null && RestfulUtil.isRpcRequest(httpRequest)) {
       return RestfulUtil.serializeError(exception);
     }
 

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/undertow/UndertowEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/undertow/UndertowEndpointFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2009-2016 Weibo, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support.undertow;
+
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.protocol.restful.RestServer;
+import com.weibo.api.motan.protocol.restful.support.AbstractEndpointFactory;
+import com.weibo.api.motan.rpc.URL;
+
+/**
+ * @author wangjunwei
+ * @since 2017-06-26
+ */
+@SpiMeta(name = "undertow")
+public class UndertowEndpointFactory extends AbstractEndpointFactory {
+
+    @Override
+    protected RestServer innerCreateServer(URL url) {
+        return new UndertowServer(url);
+    }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/undertow/UndertowServer.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/undertow/UndertowServer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2009-2016 Weibo, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.weibo.api.motan.protocol.restful.support.undertow;
+
+import com.weibo.api.motan.protocol.restful.EmbedRestServer;
+import com.weibo.api.motan.rpc.URL;
+import io.undertow.Undertow;
+import io.undertow.servlet.api.DeploymentInfo;
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+/**
+ * 使用 Undertow 的 RestServer
+ *
+ * @author wangjunwei
+ * @since 2017-06-26
+ */
+public class UndertowServer extends EmbedRestServer {
+    private final URL url;
+    private final ResteasyDeployment resteasyDeployment = new ResteasyDeployment();
+    private final UndertowJaxrsServer undertowJaxrsServer = new UndertowJaxrsServer();
+
+    public UndertowServer(URL url) {
+        super(null);
+        this.url = url;
+    }
+
+    @Override
+    public void start() {
+        resteasyDeployment.start();
+
+        final DeploymentInfo deploymentInfo = undertowJaxrsServer.undertowDeployment(resteasyDeployment)
+                .setContextPath("/")
+                .setDeploymentName("motan-restful")
+                .setClassLoader(Thread.currentThread().getContextClassLoader());
+
+        undertowJaxrsServer.deploy(deploymentInfo).start(Undertow.builder().addHttpListener(url.getPort(), url.getHost()));
+    }
+
+    @Override
+    public ResteasyDeployment getDeployment() {
+        return resteasyDeployment;
+    }
+
+    @Override
+    public void stop() {
+        resteasyDeployment.stop();
+        undertowJaxrsServer.stop();
+    }
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/resources/META-INF/services/com.weibo.api.motan.protocol.restful.EndpointFactory
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/resources/META-INF/services/com.weibo.api.motan.protocol.restful.EndpointFactory
@@ -16,3 +16,4 @@
 
 com.weibo.api.motan.protocol.restful.support.netty.NettyEndpointFactory
 com.weibo.api.motan.protocol.restful.support.servlet.ServletEndpointFactory
+com.weibo.api.motan.protocol.restful.support.undertow.UndertowEndpointFactory

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestRestful.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestRestful.java
@@ -45,6 +45,7 @@ public class TestRestful {
 		protocolConfig.setName("restful");
 		protocolConfig.setEndpointFactory(this.getEndpointFactory());
 		protocolConfig.setParameters(this.getProtocolExtParameters());
+		protocolConfig.setRequestTimeout(5000);
 
 		RegistryConfig registryConfig = new RegistryConfig();
 		registryConfig.setName("local");

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestRestfulWithUndertow.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestRestfulWithUndertow.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2009-2016 Weibo, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import org.junit.Test;
+
+/**
+ * @author wangjunwei
+ * @since 2017-06-26
+ */
+public class TestRestfulWithUndertow extends TestRestful {
+
+    @Override
+    protected String getEndpointFactory() {
+        return "undertow";
+    }
+
+
+    @Test
+    public void testReturnResponse() {
+        super.testReturnResponse();
+    }
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestServletContainerRestful.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestServletContainerRestful.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * @author zhouhaocheng
  *
  */
-public class TestServletCotainerRestful extends TestRestful{
+public class TestServletContainerRestful extends TestRestful {
 	private Tomcat tomcat;
 
 	private final String contextpath = "/cp";

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestServletCotainerRestful.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestServletCotainerRestful.java
@@ -15,30 +15,17 @@
  */
 package com.weibo.api.motan.protocol.restful;
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
+import com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContainerListener;
 import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.startup.Tomcat;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
-import com.weibo.api.motan.config.ProtocolConfig;
-import com.weibo.api.motan.config.RefererConfig;
-import com.weibo.api.motan.config.RegistryConfig;
-import com.weibo.api.motan.config.ServiceConfig;
-import com.weibo.api.motan.protocol.restful.HelloResource.User;
-import com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContainerListener;
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * servlet容器下restful协议测试
@@ -46,27 +33,22 @@ import com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContai
  * @author zhouhaocheng
  *
  */
-public class TestServletCotainerRestful {
+public class TestServletCotainerRestful extends TestRestful{
 	private Tomcat tomcat;
 
-	private ServiceConfig<HelloResource> serviceConfig;
-	private RefererConfig<HelloResource> refererConfig;
-	private HelloResource resource;
+	private final String contextpath = "/cp";
+	private final String servletPrefix = "/servlet";
 
-	@Before
-	public void setUp() throws Exception {
+	@Override
+	protected void beforeInit() throws LifecycleException {
 		tomcat = new Tomcat();
 		String baseDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
 		tomcat.setBaseDir(baseDir);
-		tomcat.setPort(8002);
+		tomcat.setPort(getPort());
 
 		tomcat.getConnector().setProperty("URIEncoding", "UTF-8");
 		tomcat.getConnector().setProperty("socket.soReuseAddress", "true");
 		tomcat.getConnector().setProperty("connectionTimeout", "20000");
-
-		String contextpath = "/cp";
-
-		String servletPrefix = "/servlet";
 
 		/**
 		 * <pre>
@@ -102,85 +84,21 @@ public class TestServletCotainerRestful {
 		context.addApplicationListener(RestfulServletContainerListener.class.getName());
 
 		tomcat.start();
-
-		ProtocolConfig protocolConfig = new ProtocolConfig();
-		protocolConfig.setId("testRpc");
-		protocolConfig.setName("restful");
-		protocolConfig.setEndpointFactory("servlet");
-
-		Map<String, String> ext = new HashMap<String, String>();
-		ext.put("contextpath", contextpath + servletPrefix);
-		protocolConfig.setParameters(ext);
-
-		RegistryConfig registryConfig = new RegistryConfig();
-		registryConfig.setName("local");
-		registryConfig.setAddress("127.0.0.1");
-		registryConfig.setPort(0);
-
-		serviceConfig = new ServiceConfig<HelloResource>();
-		serviceConfig.setRef(new RestHelloResource());
-		serviceConfig.setInterface(HelloResource.class);
-		serviceConfig.setProtocol(protocolConfig);
-		// 注意此处配置的端口并不会被使用，建议配置servlet服务器端口
-		serviceConfig.setExport("testRpc:8003");
-		serviceConfig.setFilter("serverf");
-		serviceConfig.setGroup("test-group");
-		serviceConfig.setVersion("0.0.3");
-		serviceConfig.setRegistry(registryConfig);
-
-		serviceConfig.export();
-
-		refererConfig = new RefererConfig<HelloResource>();
-		refererConfig.setDirectUrl("127.0.0.1:8002");
-		refererConfig.setGroup("test-group");
-		refererConfig.setVersion("0.0.3");
-		refererConfig.setFilter("clientf");
-		refererConfig.setProtocol(protocolConfig);
-		refererConfig.setInterface(HelloResource.class);
-
-		resource = refererConfig.getRef();
 	}
 
-	@Test
-	public void testPrimitiveType() {
-		Assert.assertEquals("helloworld", resource.testPrimitiveType());
+	@Override
+	protected String getEndpointFactory() {
+		return "servlet";
 	}
 
-	@Test
-	public void testCookie() {
-		List<User> users = resource.hello(23);
-		Assert.assertEquals(users.size(), 1);
-		Assert.assertEquals(users.get(0).getId(), 23);
-		Assert.assertEquals(users.get(0).getName(), "de");
+	@Override
+	protected Map<String, String> getProtocolExtParameters() {
+		return Collections.singletonMap("contextpath", contextpath + servletPrefix);
 	}
 
-	@Test
-	public void testReturnResponse() {
-		Response resp = resource.add(2, "de");
-		Assert.assertEquals(resp.getStatus(), Status.OK.getStatusCode());
-		Assert.assertEquals(resp.getCookies().size(), 1);
-		Assert.assertEquals(resp.getCookies().get("ck").getName(), "ck");
-		Assert.assertEquals(resp.getCookies().get("ck").getValue(), "2");
-
-		User user = resp.readEntity(User.class);
-		resp.close();
-
-		Assert.assertEquals(user.getId(), 2);
-		Assert.assertEquals(user.getName(), "de");
-	}
-
-	@Test(expected = UnsupportedOperationException.class)
-	public void testException() {
-		resource.testException();
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		serviceConfig.unexport();
-		refererConfig.destroy();
-
+	@Override
+	protected void clean() throws Exception {
 		tomcat.stop();
 		tomcat.destroy();
 	}
-
 }


### PR DESCRIPTION
1. 修改了几处拼写错误，为 `isRpcRequest` 判断逻辑抽出一个静态方法；
2. 增加了对 Undertow 的支持；
3. 升级 resteasy 版本到 3.1.3.Final, 3.0.7.Final 对 cookie 的处理有 bug, 导致单元测试失败；
4. 修改了测试代码结构，使复用性更强。